### PR TITLE
Remove deprecated call to setup.py, use 'build' package instead

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,11 +45,11 @@ jobs:
       - name: Upgrade pip, setuptools and wheel
         run: |
           python -m pip install --upgrade pip
-          pip install setuptools wheel twine
+          pip install setuptools wheel build twine
 
       - name: Build and check build
         run: |
-          python setup.py sdist bdist_wheel
+          python -m build
           twine check dist/*
 
       - name: Build and publish
@@ -58,6 +58,6 @@ jobs:
           TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
           TWINE_PASSWORD: ${{ secrets.PYPI_PASSWORD }}
         run: |
-          python setup.py sdist bdist_wheel
+          python -m build
           twine check dist/*
           twine upload dist/*


### PR DESCRIPTION
Same changes as pylhc/tfs#95