### PR TITLE
Indexing fix in CTA calculation

### DIFF
--- a/optics_functions/__init__.py
+++ b/optics_functions/__init__.py
@@ -5,7 +5,7 @@ Accelerator optics related calculations, directly from tfs files.
 __title__ = "optics_functions"
 __description__ = "Calculate optics parameters from TWISS outputs."
 __url__ = "https://github.com/pylhc/optics_functions"
-__version__ = "0.1.1"
+__version__ = "0.1.2"
 __author__ = "pylhc"
 __author_email__ = "pylhc@github.com"
 __license__ = "MIT"

--- a/optics_functions/coupling.py
+++ b/optics_functions/coupling.py
@@ -341,7 +341,7 @@ def _get_weights_from_lengths(df: TfsDataFrame) -> Tuple[float, np.array]:
     # approximate length of each element (ds in integral)
     s_periodic = np.zeros(len(df) + 1)
     s_periodic[1:] = df[S].to_numpy()
-    s_periodic[0] = df[S][-1] - df.headers[LENGTH]
+    s_periodic[0] = df[S].to_numpy()[-1] - df.headers[LENGTH]
 
     # weight ds/(2*pi*R) * N (as we take the mean afterwards)
     weights = np.diff(s_periodic) / df.headers[LENGTH] * len(df)


### PR DESCRIPTION
In some methods in the CTA calculation, `df[S][-1]` was called which would error if the input dataframe is not perfectly as we expect it in its index.

This is a quick fix to take last value (`[-1]`) from the conversion of `df[S]` to a numpy array, which ensures there would not be any index error.