### PR TITLE
[FIX] Invalid escape sequences in docstrings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # optics_functions Changelog
 
+## Version 0.1.4
+
+- Fixed invalid escape sequences in docstrings that would warn in all calling code.
+
 ## Version 0.1.3
 
 - Fixed use of `np.NaN` to ensure compatibility with `numpy 2.0`.

--- a/optics_functions/__init__.py
+++ b/optics_functions/__init__.py
@@ -5,7 +5,7 @@ Accelerator optics related calculations, directly from tfs files.
 __title__ = "optics_functions"
 __description__ = "Calculate optics parameters from TWISS outputs."
 __url__ = "https://github.com/pylhc/optics_functions"
-__version__ = "0.1.3"
+__version__ = "0.1.4"
 __author__ = "pylhc"
 __author_email__ = "pylhc@github.com"
 __license__ = "MIT"

--- a/optics_functions/coupling.py
+++ b/optics_functions/coupling.py
@@ -349,7 +349,7 @@ def _get_weights_from_lengths(df: TfsDataFrame) -> Tuple[float, np.array]:
 
 
 def check_resonance_relation(df: DataFrame, to_nan: bool = False) -> DataFrame:
-    """Checks that \|F1001| >= \|F1010|.
+    r"""Checks that \|F1001| >= \|F1010|.
     If desired, sets the invalid points to NaN. This is only used for checking
     in the :func:`~optics_functions.coupling.closest_tune_approach` function,
     but can be invoked by the user with ``to_nan = True`` and the resulting

--- a/optics_functions/rdt.py
+++ b/optics_functions/rdt.py
@@ -27,7 +27,7 @@ def calculate_rdts(df: TfsDataFrame, rdts: Sequence[str],
                    qx: float = None, qy: float = None, feeddown: int = 0,
                    complex_columns: bool = True, loop_phases: bool = False,
                    hamiltionian_terms: bool = False) -> TfsDataFrame:
-    """ Calculates the Resonance Driving Terms.
+    r"""Calculates the Resonance Driving Terms.
 
     Eq. (A8) in [FranchiAnalyticFormulas2017]_ .
     One might notice that this code implementation has a factor :math:`2 \pi` in the exponential

--- a/tests/unit/test_coupling.py
+++ b/tests/unit/test_coupling.py
@@ -114,7 +114,7 @@ def test_closest_tune_approach(
     df_twiss[F1001] = df_cmatrix[F1001]  # ignoring F1010 in this test as it is bigger than F1001
 
     cta_df = closest_tune_approach(df_twiss, method=cta_method)  # only one column
-    cminus = cta_df.mean().abs()[0]
+    cminus = cta_df.mean().abs().iloc[0]
     relative_error = _relative_error(cminus, _coupling_bump_teapot_cta)
 
     assert relative_error <= max_relative_error_to_teapot
@@ -212,4 +212,4 @@ def _coupling_bump_teapot_cta() -> float:
     df_twiss[F1001] = df_cmatrix[F1001]  # ignoring F1010 in this test as it is bigger than F1001
 
     cta_df = closest_tune_approach(df_twiss, method="teapot")  # only one column
-    return cta_df.mean().abs()[0]  # this is the cminus
+    return cta_df.mean().abs().iloc[0]  # this is the cminus

--- a/tests/unit/test_coupling.py
+++ b/tests/unit/test_coupling.py
@@ -176,12 +176,13 @@ def test_coupling_rdt_bump_cmatrix_compare():
 
 def generate_fake_data(n) -> tfs.TfsDataFrame:
     qx, qy = 1.31, 1.32
-    df = tfs.TfsDataFrame(0,
-                          index=[str(i) for i in range(n)],
-                          columns=[S, f"{ALPHA}{X}", f"{ALPHA}{Y}", f"{BETA}{X}", f"{BETA}{Y}",
-                                   f"{PHASE_ADV}{X}", f"{PHASE_ADV}{Y}", "R11", "R12", "R21", "R22"],
-                          headers={f"{TUNE}1": qx, f"{TUNE}2": qy}
-                          )
+    df = tfs.TfsDataFrame(
+        0.0,
+        index=[str(i) for i in range(n)],
+        columns=[S, f"{ALPHA}{X}", f"{ALPHA}{Y}", f"{BETA}{X}", f"{BETA}{Y}",
+                f"{PHASE_ADV}{X}", f"{PHASE_ADV}{Y}", "R11", "R12", "R21", "R22"],
+        headers={f"{TUNE}1": qx, f"{TUNE}2": qy},
+    )
 
     r = np.random.rand(n)
     df[S] = np.linspace(0, n, n)


### PR DESCRIPTION
There were two places in `optics_functions` that would emit the `SyntaxWarning: invalid escape sequence ...`

This PR fixes it, so we can stop polluting CIs & co.
I am also including some very minor fixes for warnings emerging in the tests (but from test code).

Updated the version with a patch so we can release in the wild.