### PR TITLE
Pandas 3.x compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,26 +15,26 @@
 ## Version 0.1.2
 
 - Fixed:
-  - an issue that could lead to an indexing error in the closest tune approach calculation for some of the available methods.
+    - an issue that could lead to an indexing error in the closest tune approach calculation for some of the available methods.
 
 ## Version 0.1.1
 
 A patch for some closest tune approach methods, and the addition of new methods.
 
 - Fixed:
-  - Closest tune approach calculation now properly checks for the resonance relation between f1001 and f1010 resonance driving terms.
-  - Closest tune approach calculation now properly takes into account weights from element lengths
+    - Closest tune approach calculation now properly checks for the resonance relation between f1001 and f1010 resonance driving terms.
+    - Closest tune approach calculation now properly takes into account weights from element lengths
 
 - Added:
-  - New methods for closest tune approach calculation: `teapot` (equivalent to `calaga`), `teapot_franchi`, `hoydalsvik` and `hoydalsvik_alt`. References can be found in the documentation.
-  - Additional tests and checks.
+    - New methods for closest tune approach calculation: `teapot` (equivalent to `calaga`), `teapot_franchi`, `hoydalsvik` and `hoydalsvik_alt`. References can be found in the documentation.
+    - Additional tests and checks.
 
 ## Version 0.1.0
 
 - Added:
-  - Coupling calculations
-  - RDT calculations
-  - Utilities
-  - Tests for coupling, rdt and utils
-  - Documentation
-  - Workflows
+    - Coupling calculations
+    - RDT calculations
+    - Utilities
+    - Tests for coupling, rdt and utils
+    - Documentation
+    - Workflows

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # optics_functions Changelog
 
+## Version 0.1.6
+
+- Added compatibility with `pandas 3.x`.
+
 ## Version 0.1.5
 
 - Dropped support for `Python 3.9`.

--- a/optics_functions/__init__.py
+++ b/optics_functions/__init__.py
@@ -5,7 +5,7 @@ Accelerator optics related calculations, directly from tfs files.
 __title__ = "optics_functions"
 __description__ = "Calculate optics parameters from TWISS outputs."
 __url__ = "https://github.com/pylhc/optics_functions"
-__version__ = "0.1.5"
+__version__ = "0.1.6"
 __author__ = "pylhc"
 __author_email__ = "pylhc@github.com"
 __license__ = "MIT"

--- a/optics_functions/coupling.py
+++ b/optics_functions/coupling.py
@@ -70,8 +70,11 @@ def coupling_via_rdts(df: TfsDataFrame, complex_columns: bool = True, **kwargs) 
         A new ``TfsDataFrame`` with Coupling Columns.
     """
     df_res = calculate_rdts(df, rdts=COUPLING_RDTS, **kwargs)
+
+    # Change real part of the RDT for consistency with Calaga approach
+    # (see references in the function's docstring)
     for rdt in COUPLING_RDTS:
-        rdt_array = df_res[rdt].to_numpy()  # might return a copy!
+        rdt_array = df_res[rdt].to_numpy(copy=True)  # enforce copy so we can modify it
         rdt_array.real *= -1  # definition
         df_res.loc[:, rdt] = rdt_array
 


### PR DESCRIPTION
Since the default copy-on-write behavior of pandas 3.x, Accessing the underlying NumPy array of a DataFrame will return a read-only array if the array shares data with the initial DataFrame. This is always the case for a `pd.Series` because there is only one array. See https://pandas.pydata.org/docs/user_guide/copy_on_write.html#read-only-numpy-arrays

A simple fix is to force a copy in our previously faulty line. It is not the most efficient way to do things but it is only done twice (once for each coupling RDT) and we never have billions of elements in our lattice so it won't be a performance issue.